### PR TITLE
Changed yolo_anchorsv4.txt to yolo_anchors.txt

### DIFF
--- a/OneStage/yolo/deep_sort_yolov4/convert.py
+++ b/OneStage/yolo/deep_sort_yolov4/convert.py
@@ -161,7 +161,7 @@ class Yolo4(object):
 
 if __name__ == '__main__':
     model_path = 'yolo4_weight.h5'
-    anchors_path = 'model_data/yolo4_anchors.txt'
+    anchors_path = 'model_data/yolo_anchors.txt'
     classes_path = 'model_data/coco_classes.txt'
     weights_path = 'yolov4.weights'
 


### PR DESCRIPTION
Problem in execution of convert.py because of the wrong anchor location.